### PR TITLE
In order to catch exception when we have lost Kafka

### DIFF
--- a/src/main/java/io/adopteunops/monitoring/kafka/exporter/KafkaExporter.java
+++ b/src/main/java/io/adopteunops/monitoring/kafka/exporter/KafkaExporter.java
@@ -59,26 +59,32 @@ class KafkaExporter {
         return AdminClient.create(props);
     }
 
-    synchronized void updateMetrics() {
+   synchronized void updateMetrics() {
 
-        Collection<GroupOverview> groupOverviews = asJavaCollectionConverter(adminClient.listAllConsumerGroupsFlattened()).asJavaCollection();
-        List<String> groups = groupOverviews.stream()
-                .map(GroupOverview::groupId)
-                .filter(g -> !groupBlacklistPattern.matcher(g).matches())
-                .collect(toList());
+        try {
+            Collection<GroupOverview> groupOverviews = asJavaCollectionConverter(adminClient.listAllConsumerGroupsFlattened()).asJavaCollection();
 
-        groups.forEach(group -> {
-            Map<TopicPartition, Object> offsets = mapAsJavaMapConverter(adminClient.listGroupOffsets(group)).asJava();
-            offsets.forEach((k, v) -> {
-                TopicPartition topicPartition = new TopicPartition(k.topic(), k.partition());
-                Long currentOffset = new Long(v.toString());
-                Long lag = getLogEndOffset(topicPartition) - currentOffset;
-                String partition = String.valueOf(k.partition());
+            List<String> groups = groupOverviews.stream()
+                    .map(GroupOverview::groupId)
+                    .filter(g -> !groupBlacklistPattern.matcher(g).matches())
+                    .collect(toList());
 
-                gaugeOffsetLag.labels(group, partition, k.topic()).set(lag);
-                gaugeCurrentOffset.labels(group, partition, k.topic()).set(currentOffset);
+            groups.forEach(group -> {
+                Map<TopicPartition, Object> offsets = mapAsJavaMapConverter(adminClient.listGroupOffsets(group)).asJava();
+                offsets.forEach((k, v) -> {
+                    TopicPartition topicPartition = new TopicPartition(k.topic(), k.partition());
+                    Long currentOffset = new Long(v.toString());
+                    Long lag = getLogEndOffset(topicPartition) - currentOffset;
+                    String partition = String.valueOf(k.partition());
+
+                    gaugeOffsetLag.labels(group, partition, k.topic()).set(lag);
+                    gaugeCurrentOffset.labels(group, partition, k.topic()).set(currentOffset);
+                });
             });
-        });
+
+        } catch (java.lang.RuntimeException ex) {
+            ex.printStackTrace();
+        }
     }
 
     private long getLogEndOffset(TopicPartition topicPartition) {


### PR DESCRIPTION
The method listAllConsumerGroupsFlattened can trigger an exception if we have lost Kafka (see below).

16/01/2018 21:19:50Exception in thread "Timer-0" java.lang.RuntimeException: Request METADATA failed on brokers List(kafka:9092 (id: -1 rack: null))
16/01/2018 21:19:50	at kafka.admin.AdminClient.kafka$admin$AdminClient$$sendAnyNode(AdminClient.scala:103)
16/01/2018 21:19:50	at kafka.admin.AdminClient.findAllBrokers(AdminClient.scala:161)
16/01/2018 21:19:50	at kafka.admin.AdminClient.listAllGroups(AdminClient.scala:169)
16/01/2018 21:19:50	at kafka.admin.AdminClient.listAllGroupsFlattened(AdminClient.scala:189)
16/01/2018 21:19:50	at kafka.admin.AdminClient.listAllConsumerGroupsFlattened(AdminClient.scala:193)
16/01/2018 21:19:50	at io.adopteunops.monitoring.kafka.exporter.KafkaExporter.updateMetrics(KafkaExporter.java:64)
16/01/2018 21:19:50	at io.adopteunops.monitoring.kafka.exporter.Main$1.run(Main.java:63)
16/01/2018 21:19:50	at java.util.TimerThread.mainLoop(Timer.java:555)
16/01/2018 21:19:50	at java.util.TimerThread.run(Timer.java:505)

I propose to add a block try/catch to handle this problem.